### PR TITLE
Add Playwright E2E tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "next lint",
     "analyze": "ANALYZE=true next build",
     "setup": "./setup.sh",
-    "quick-start": "./quick-start.sh"
+    "quick-start": "./quick-start.sh",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.18",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true
+  },
+});

--- a/tests/e2e/error-page.spec.ts
+++ b/tests/e2e/error-page.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('shows 404 page on invalid route', async ({ page }) => {
+  const response = await page.goto('/non-existent-route');
+  expect(response?.status()).toBe(404);
+  await expect(page.getByText(/something went wrong/i)).toBeVisible();
+});

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+
+test('landing page renders key sections', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: /master any topic/i })).toBeVisible();
+  await expect(page.getByRole('heading', { name: /pricing/i })).toBeVisible();
+  await expect(page.getByRole('link', { name: /get started/i })).toBeVisible();
+  await expect(page.getByText('©')).toBeVisible();
+});

--- a/tests/e2e/progress-resume.spec.ts
+++ b/tests/e2e/progress-resume.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+const quizId = 'azure-a102';
+
+test('resume prompt appears when progress exists', async ({ page }) => {
+  await page.route('**/api/user/quiz-progress**', route => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ progress: { current_question_index: 1, user_answers: {}, last_saved_at: new Date().toISOString() } })
+      });
+    }
+    return route.continue();
+  });
+
+  await page.goto(`/quiz-test/${quizId}/single_selection`);
+  await expect(page.getByText(/continue/i)).toBeVisible();
+});

--- a/tests/e2e/quiz-flow.spec.ts
+++ b/tests/e2e/quiz-flow.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+const quizId = 'azure-a102';
+const questionTypes = [
+  'single_selection',
+  'multi',
+  'drag_and_drop',
+  'order',
+  'yes_no',
+  'dropdown_selection',
+  'yesno_multi'
+];
+
+for (const type of questionTypes) {
+  test(`load ${type} question`, async ({ page }) => {
+    await page.goto(`/quiz-test/${quizId}/${type}`);
+    await expect(page.locator('.question-text')).toBeVisible();
+  });
+}

--- a/tests/e2e/static-pages.spec.ts
+++ b/tests/e2e/static-pages.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+test('terms of service page loads', async ({ page }) => {
+  await page.goto('/tos');
+  await expect(page.getByRole('heading', { name: /terms and conditions/i })).toBeVisible();
+});
+
+test('privacy policy page loads', async ({ page }) => {
+  await page.goto('/privacy-policy');
+  await expect(page.getByRole('heading', { name: /privacy policy/i })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- configure Playwright
- add basic E2E tests for landing page, static pages, quiz routes and resume prompt

## Testing
- `npx playwright test tests/e2e/landing.spec.ts --reporter=line` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_683f4927a2dc832a86878c74be86a815