### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test --if-present
+      - run: npm run build
+      - name: Upload build logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-logs
+          path: .next
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/deploy.sh production
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  notify:
+    needs: [build, deploy]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack
+        uses: rtCamp/action-slack-notify@v2
+        if: always()
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          MSG_TITLE: "CI ${{ job.status }}"

--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ npm run test:watch
 npm run test:coverage
 ```
 
+## 🔄 Continuous Integration
+
+GitHub Actions automatically runs linting, unit tests and a production build on every pull request. Deployments are triggered via `scripts/deploy.sh` when changes land on the `main` branch. Configure the `SLACK_WEBHOOK_URL` secret to receive build notifications in Slack.
+
 ## 📁 Project Structure
 
 ```

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "analyze": "ANALYZE=true next build",
     "setup": "./setup.sh",
     "quick-start": "./quick-start.sh",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
     "test:e2e": "playwright test"
   },
   "dependencies": {
@@ -67,6 +70,7 @@
     "autoprefixer": "^10.4.19",
     "daisyui": "^4.10.1",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.0.0-beta.3",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.3",
     "ts-jest": "^29.3.4",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+ENV=${1:-staging}
+
+echo "Deploying application to $ENV environment"
+
+# TODO: Replace the following with your actual deployment commands
+# For example: npm run deploy:$ENV or a serverless deployment
+
+exit 0


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running lint, tests and build
- create placeholder deployment script
- document the CI pipeline in README
- expose `npm test` scripts in package.json

## Testing
- `npm test` *(fails: exceeded timeout and missing modules)*
- `npm run lint`
- `npm run build` *(fails: failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_683fc3d67714832a92c17681a7ea955f