### PR TITLE
Fix author page TypeScript definitions

### DIFF
--- a/app/blog/author/[authorId]/page.tsx
+++ b/app/blog/author/[authorId]/page.tsx
@@ -7,10 +7,10 @@ import config from "@/config";
 export async function generateMetadata({
   params,
 }: {
-  params: { authorId: string };
+  params: Promise<{ authorId: string }>;
 }) {
-  const resolvedParams = await params;
-  const author = authors.find((author) => author.slug === resolvedParams.authorId);
+  const { authorId } = await params;
+  const author = authors.find((author) => author.slug === authorId);
 
   return getSEOTags({
     title: `${author.name}, Author at ${config.appName}'s Blog`,
@@ -22,10 +22,10 @@ export async function generateMetadata({
 export default async function Author({
   params,
 }: {
-  params: { authorId: string };
+  params: Promise<{ authorId: string }>;
 }) {
-  const resolvedParams = await params;
-  const author = authors.find((author) => author.slug === resolvedParams.authorId);
+  const { authorId } = await params;
+  const author = authors.find((author) => author.slug === authorId);
   const articlesByAuthor = articles
     .filter((article) => article.author.slug === author.slug)
     .sort(

--- a/types/next.d.ts
+++ b/types/next.d.ts
@@ -2,8 +2,10 @@ import type { NextPage, NextPageContext, NextComponentType } from 'next';
 
 declare module 'next' {
   export type PageProps = {
-    params: { [key: string]: string | string[] };
-    searchParams?: { [key: string]: string | string[] | undefined };
+    params: Promise<{ [key: string]: string | string[] }> | { [key: string]: string | string[] };
+    searchParams?:
+      | Promise<{ [key: string]: string | string[] | undefined }>
+      | { [key: string]: string | string[] | undefined };
   }
 
   export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {


### PR DESCRIPTION
## Summary
- update `PageProps` typings to accept Promises
- align author page route with Next.js 15 `PageProps` behavior

## Testing
- `npm run build` *(fails: Failed to fetch Inter font)*
- `npm test` *(fails: multiple Jest/Playwright errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840a45ab0ec832a9e7c8a91bc5695b7